### PR TITLE
Add n50 and missing stats exceptions

### DIFF
--- a/pbreports/report/adapter_xml.py
+++ b/pbreports/report/adapter_xml.py
@@ -43,6 +43,8 @@ def to_report(stats_xml, output_dir, dpi=72):
     dset = DataSet(stats_xml)
     if not dset.metadata.summaryStats:
         dset.loadStats(stats_xml)
+    if not dset.metadata.summaryStats.medianInsertDists:
+        raise RuntimeError("No Pipeline Summary Stats (sts.xml) found")
 
     # Pull some stats:
     adapter_dimers = np.round(

--- a/pbreports/report/loading_xml.py
+++ b/pbreports/report/loading_xml.py
@@ -38,6 +38,8 @@ def to_report(stats_xml):
     dset = DataSet(stats_xml)
     if not dset.metadata.summaryStats:
         dset.loadStats(stats_xml)
+    if not dset.metadata.summaryStats.prodDist:
+        raise RuntimeError("No Pipeline Summary Stats (sts.xml) found")
 
     dsets = [dset]
     for subdset in dset.subdatasets:

--- a/tests/unit/test_pbreports_report_stats_xml_reports.py
+++ b/tests/unit/test_pbreports_report_stats_xml_reports.py
@@ -321,7 +321,7 @@ class TestXMLstatsRpts(unittest.TestCase):
                              'filter_stats_column', c1['id'])
             self.assertEqual(4464266.29, c1['values'][0])
             self.assertEqual(901, c1['values'][1])
-            self.assertEqual(0, c1['values'][2])
+            self.assertEqual(6570, c1['values'][2])
             self.assertEqual(4954.79, c1['values'][3])
             self.assertEqual(0.83, c1['values'][4])
             self.assertTrue(os.path.exists(os.path.join(
@@ -365,7 +365,7 @@ class TestXMLstatsRpts(unittest.TestCase):
                              'filter_stats_column', c1['id'])
             self.assertEqual(393167212.65, c1['values'][0])
             self.assertEqual(25123, c1['values'][1])
-            self.assertEqual(0, c1['values'][2])
+            self.assertEqual(21884, c1['values'][2])
             self.assertEqual(15649.69, c1['values'][3])
             self.assertEqual(0.86, c1['values'][4])
             self.assertTrue(os.path.exists(os.path.join(


### PR DESCRIPTION
Add n50 to filter stats report based on sts.xml.
Raise exception when sts.xml or summaryStats not found.