### PR TITLE
Add mechanisms for managing outsized continuous distributions

### DIFF
--- a/pbreports/report/adapter_xml.py
+++ b/pbreports/report/adapter_xml.py
@@ -9,6 +9,7 @@ import sys
 
 import numpy as np
 
+from pbreports.util import dist_shaper
 from pbcommand.models.report import Report, Table, Column, PlotGroup, Plot
 from pbcommand.common_options import add_debug_option
 from pbcommand.models import FileTypes, get_pbparser
@@ -58,8 +59,10 @@ def to_report(stats_xml, output_dir, dpi=72):
 
     plots = []
     # Pull some histograms (may have dupes (unmergeable distributions)):
-    for i, ins_len_dist in enumerate(
+    shaper = dist_shaper(dset.metadata.summaryStats.medianInsertDists)
+    for i, orig_ins_len_dist in enumerate(
             dset.metadata.summaryStats.medianInsertDists):
+        ins_len_dist = shaper(orig_ins_len_dist)
         # make a bar chart:
         fig, ax = get_fig_axes_lpr()
         ax.bar(map(float, ins_len_dist.labels), ins_len_dist.bins,

--- a/pbreports/report/filter_stats_xml.py
+++ b/pbreports/report/filter_stats_xml.py
@@ -22,7 +22,7 @@ from pbcore.io import DataSet
 
 from pbreports.plot.helper import (get_fig_axes_lpr,
                                    save_figure_with_thumbnail, get_green)
-from pbreports.util import compute_n50
+from pbreports.util import compute_n50, dist_shaper
 
 __version__ = '0.1.0'
 
@@ -73,8 +73,11 @@ def to_report(stats_xml, output_dir, dpi=72):
     readscorenumber = 0
     approx_read_lens = []
 
+
     # if a merge failed there may be more than one dist:
-    for rlendist in dset.metadata.summaryStats.readLenDists:
+    shaper = dist_shaper(dset.metadata.summaryStats.readLenDists)
+    for orig_rlendist in dset.metadata.summaryStats.readLenDists:
+        rlendist = shaper(orig_rlendist)
         nbases += _total_from_bins(rlendist.bins,
                                    rlendist.minBinValue,
                                    rlendist.binWidth)
@@ -98,7 +101,9 @@ def to_report(stats_xml, output_dir, dpi=72):
             # approx_read_lens.append(rlendist.maxBinValue)
     n50 = np.round(compute_n50(approx_read_lens))
 
-    for rqualdist in dset.metadata.summaryStats.readQualDists:
+    shaper = dist_shaper(dset.metadata.summaryStats.readQualDists)
+    for orig_rqualdist in dset.metadata.summaryStats.readQualDists:
+        rqualdist = shaper(orig_rqualdist)
         readscoretotal += _total_from_bins(rqualdist.bins,
                                            rqualdist.minBinValue,
                                            rqualdist.binWidth)
@@ -124,7 +129,9 @@ def to_report(stats_xml, output_dir, dpi=72):
     plots = []
 
     # ReadLen distribution to barplot:
-    for i, rlendist in enumerate(dset.metadata.summaryStats.readLenDists):
+    shaper = dist_shaper(dset.metadata.summaryStats.readLenDists)
+    for i, orig_rlendist in enumerate(dset.metadata.summaryStats.readLenDists):
+        rlendist = shaper(orig_rlendist)
         len_fig, len_axes = get_fig_axes_lpr()
         len_axes.bar(rlendist.labels, rlendist.bins,
                      color=get_green(0), edgecolor=get_green(0),
@@ -147,7 +154,9 @@ def to_report(stats_xml, output_dir, dpi=72):
     plots = []
 
     # ReadQual distribution to barplot:
-    for i, rqualdist in enumerate(dset.metadata.summaryStats.readQualDists):
+    shaper = dist_shaper(dset.metadata.summaryStats.readQualDists)
+    for i, orig_rqualdist in enumerate(dset.metadata.summaryStats.readQualDists):
+        rqualdist = shaper(orig_rqualdist)
         qual_fig, qual_axes = get_fig_axes_lpr()
         qual_axes.bar(rqualdist.labels, rqualdist.bins,
                       color=get_green(0), edgecolor=get_green(0),


### PR DESCRIPTION
dist_shaper will take a list of distributions that you would like to all look
similar but better (e.g. not 200 bins, usually) and (optionally) some number of
bins you would like to see, and returns a closure that will reshape those
distributions as you iterate over them. This will trim emtpy bins and can pool
bins if necessary.