### PR TITLE
Abstract dist_shaper, fewer constraints

### DIFF
--- a/pbreports/report/adapter_xml.py
+++ b/pbreports/report/adapter_xml.py
@@ -9,7 +9,7 @@ import sys
 
 import numpy as np
 
-from pbreports.util import dist_shaper
+from pbreports.util import continuous_dist_shaper
 from pbcommand.models.report import Report, Table, Column, PlotGroup, Plot
 from pbcommand.common_options import add_debug_option
 from pbcommand.models import FileTypes, get_pbparser
@@ -59,7 +59,7 @@ def to_report(stats_xml, output_dir, dpi=72):
 
     plots = []
     # Pull some histograms (may have dupes (unmergeable distributions)):
-    shaper = dist_shaper(dset.metadata.summaryStats.medianInsertDists)
+    shaper = continuous_dist_shaper(dset.metadata.summaryStats.medianInsertDists)
     for i, orig_ins_len_dist in enumerate(
             dset.metadata.summaryStats.medianInsertDists):
         ins_len_dist = shaper(orig_ins_len_dist)

--- a/pbreports/report/filter_stats_xml.py
+++ b/pbreports/report/filter_stats_xml.py
@@ -22,7 +22,7 @@ from pbcore.io import DataSet
 
 from pbreports.plot.helper import (get_fig_axes_lpr,
                                    save_figure_with_thumbnail, get_green)
-from pbreports.util import compute_n50, dist_shaper
+from pbreports.util import compute_n50, continuous_dist_shaper
 
 __version__ = '0.1.0'
 
@@ -75,9 +75,7 @@ def to_report(stats_xml, output_dir, dpi=72):
 
 
     # if a merge failed there may be more than one dist:
-    shaper = dist_shaper(dset.metadata.summaryStats.readLenDists)
-    for orig_rlendist in dset.metadata.summaryStats.readLenDists:
-        rlendist = shaper(orig_rlendist)
+    for rlendist in dset.metadata.summaryStats.readLenDists:
         nbases += _total_from_bins(rlendist.bins,
                                    rlendist.minBinValue,
                                    rlendist.binWidth)
@@ -101,9 +99,7 @@ def to_report(stats_xml, output_dir, dpi=72):
             # approx_read_lens.append(rlendist.maxBinValue)
     n50 = np.round(compute_n50(approx_read_lens))
 
-    shaper = dist_shaper(dset.metadata.summaryStats.readQualDists)
-    for orig_rqualdist in dset.metadata.summaryStats.readQualDists:
-        rqualdist = shaper(orig_rqualdist)
+    for rqualdist in dset.metadata.summaryStats.readQualDists:
         readscoretotal += _total_from_bins(rqualdist.bins,
                                            rqualdist.minBinValue,
                                            rqualdist.binWidth)
@@ -129,7 +125,7 @@ def to_report(stats_xml, output_dir, dpi=72):
     plots = []
 
     # ReadLen distribution to barplot:
-    shaper = dist_shaper(dset.metadata.summaryStats.readLenDists)
+    shaper = continuous_dist_shaper(dset.metadata.summaryStats.readLenDists)
     for i, orig_rlendist in enumerate(dset.metadata.summaryStats.readLenDists):
         rlendist = shaper(orig_rlendist)
         len_fig, len_axes = get_fig_axes_lpr()
@@ -154,7 +150,7 @@ def to_report(stats_xml, output_dir, dpi=72):
     plots = []
 
     # ReadQual distribution to barplot:
-    shaper = dist_shaper(dset.metadata.summaryStats.readQualDists)
+    shaper = continuous_dist_shaper(dset.metadata.summaryStats.readQualDists)
     for i, orig_rqualdist in enumerate(dset.metadata.summaryStats.readQualDists):
         rqualdist = shaper(orig_rqualdist)
         qual_fig, qual_axes = get_fig_axes_lpr()

--- a/pbreports/util.py
+++ b/pbreports/util.py
@@ -413,16 +413,22 @@ def compute_n50_from_bins(bins):
     return 0
 
 def _dist_shaper(bmin, bmax, poolby, dist):
-    """Just change the bins and binlabels! Not the sample means etc."""
-    try:
-        dist = deepcopy(dist)
+    """Just change the bins and binlabels! Not the sample means etc.
 
+    Args:
+        dist: ([bin, ...], [label, ...])
+    """
+    try:
+        bins, labels = dist
+        assert len(bins) > 1, "Need more than 1 bin"
+        assert len(bins) == len(labels), "Need same bin, label count"
         # bins and labels
         first = 0
-        firstl = None
+        firstl = labels[0]
         last = 0
-        lastl = None
-        for i, l in enumerate(dist.labels):
+        lastl = labels[-1]
+        bwidth = labels[1] - labels[0]
+        for i, l in enumerate(labels):
             if l <= bmin:
                 first = i
                 firstl = l
@@ -432,41 +438,83 @@ def _dist_shaper(bmin, bmax, poolby, dist):
             else:
                 break
         # bound the range:
-        newbins = dist.bins[first:last + 1]
-        assert (len(newbins) % poolby) == 0
+        newbins = bins[first:last + 1]
+        newlabels = labels[first:last + 1]
+
+        # pad the range:
+        under = firstl - bmin
+        if under > 0:
+            lpad = int(under/bwidth)
+            newbins = [0] * lpad + newbins
+            newlabels = [newlabels[0] - (lpad - i) * bwidth
+                         for i in range(lpad)] + newlabels
+        under = bmax - lastl
+        if under > 0:
+            rpad = int(round(under/bwidth))
+            newbins = newbins + [0] * rpad
+            newlabels = newlabels + [newlabels[-1] + i * bwidth
+                                     for i in range(1, rpad + 1)]
+
+        assert (len(newbins) % poolby) == 0, ("pooling factor doesn't "
+                                              "divide new "
+                                              "nbins evenly")
 
         # collapse with poolby
-        newbins = [sum(newbins[start:start + poolby])
+        cbins = [sum(newbins[start:start + poolby])
                    for start in xrange(0, len(newbins), poolby)]
+        clabels = [newlabels[start]
+                     for start in xrange(0, len(newbins), poolby)]
 
-        dist.bins = newbins
-        dist.minBinValue = firstl
-        dist.maxBinValue = lastl
-        dist.numBins = len(dist.bins)
+        bins = cbins
+        labels = clabels
 
-    except AssertionError:
-        log.error("Malformed dist_shaper")
+    except AssertionError as e:
+        log.error("Malformed dist_shaper: " + e.message)
+    return (bins, labels)
+
+def _cont_dist_shaper(shape_func, dist):
+    """Just change the bins and binlabels! Not the sample means etc."""
+    dist = deepcopy(dist)
+    newbins, newlabels = shape_func((dist.bins, dist.labels))
+    dist.bins = newbins
+    dist.minBinValue = newlabels[0]
+    dist.maxBinValue = newlabels[-1]
+    dist.numBins = len(newbins)
     return dist
 
-def dist_shaper(dist_list, bins=40):
+def dist_shaper(dist_list, nbins=40):
     """Produce a function to modify a distribution to have a number of bins
     close to or greater than the number provided, such that all dists in the
-    dist list can be transformed to have a consistent appearance. Distributions
-    must have the same bin width!"""
+    dist list can be transformed to have a consistent appearance.
+
+    .. note:: Distributions must have the same bin width!
+    .. note:: Distributions must have the same bin boundary locations (e.g. all
+              bins must be integer multiples of binwidth)!
+
+    This does produce quite a few empty bins when you would think they could be
+    redistributed, but the rule is that redistribution can only append with
+    even pooling! No splitting data allowed, only joining.
+
+    Args:
+        dist_list: [([bin, ...], [label, ...]), ...]
+    """
     try:
-        assert bins > 0
-        assert bins < max(d.numBins for d in dist_list)
+        assert nbins > 0, "nbins must be greater than 0"
+        assert len(dist_list) >= 1
+        assert len(dist_list[0]) > 1
         bmin = sys.maxint
         bmax = 0
+        # prepare for a relaxation of the binwidth requirement (wont happen for
+        # a while):
         # we want the largest binwidth, as we have to pad up so that the
-        # coarsest distribution has ~ 40 bins, but they all cover the same
+        # coarsest distribution has ~ 40 nbins, but they all cover the same
         # range
         bwidth = 0
-        for dist in dist_list:
+        for bins, labels in dist_list:
             first = None
             last = None
-            if sum(dist.bins) > 0:
-                for i, (bv, bl) in enumerate(zip(dist.bins, dist.labels)):
+            if sum(bins) > 0:
+                for i, (bv, bl) in enumerate(zip(bins, labels)):
                     if bv != 0:
                         last = bl
                         if first is None:
@@ -475,43 +523,52 @@ def dist_shaper(dist_list, bins=40):
                     bmin = first
                 if bmax < last:
                     bmax = last
-            if dist.binWidth > bwidth:
-                bwidth = dist.binWidth
+            binWidth = labels[1] - labels[0]
+            if binWidth > bwidth:
+                bwidth = binWidth
         assert bmin <= bmax
         assert bwidth != 0
 
         # you have to add on that last bin
-        curbins = (bmax - bmin)/bwidth + 1
-        poolby = curbins/bins
-        bmin, bmax, bwidth = map(int, [bmin, bmax, bwidth])
+        curbins = int(round((bmax - bmin)/bwidth + 1))
+        poolby = curbins/float(nbins)
 
         # poolby should be an int >= 1 before it hits _dist_shaper, so if it is
         # less than that, lets adjust the other values here and now:
         if poolby < 1:
-            pad = (1 - poolby) * bins
+            # the total to be padded:
+            pad = int(round((1 - poolby) * nbins))
             pad_left = min(pad/2, (bmin/bwidth))
             pad_right = pad - pad_left
             bmin = bmin - (pad_left * bwidth)
             bmax = bmax + (pad_right * bwidth)
             curbins = (bmax - bmin)/bwidth + 1
-            poolby = curbins/bins
+            poolby = curbins/float(nbins)
+
+        curbins = int(round(curbins))
+        poolby = int(math.ceil(poolby))
 
         # poolby should be an even divisor of curbins before it hits
         # _dist_shaper, so if it isn't, lets adjust the other values here and
         # now:
         if poolby > 1:
-            curbins = (bmax - bmin)/bwidth + 1
-            poolby = math.ceil(poolby)
-            # round out that multiplier, but remember that it is relative to
+            # we don't want to end up with fewer bins than predicted, so take
+            # the max
+            curbins = int(max(round(curbins/poolby), nbins)) * int(poolby)
+            # round up that multiplier, but remember that it is relative to
             # bmin, not always zero. we only go to the beginning of the last
             # bin, so subtract one before multiplying in the binwidth
-            bmax = (bins * poolby + bmin/bwidth - 1) * bwidth
+            bmax = (curbins + bmin/bwidth - 1) * bwidth
 
         # you have to add on that last bin
-        curbins = int((bmax - bmin)/bwidth + 1)
-        poolby = int(curbins/bins)
+        curbins = int(round((bmax - bmin)/bwidth) + 1)
+        poolby = int(curbins/nbins)
         return functools.partial(_dist_shaper, bmin, bmax, poolby)
-    except AssertionError:
+    except AssertionError as e:
+        log.error(e.message)
         return lambda x: x
 
-
+def continuous_dist_shaper(dist_list, nbins=40):
+    generic_dist_list = [(d.bins, d.labels) for d in dist_list]
+    shaper = dist_shaper(generic_dist_list, nbins=nbins)
+    return functools.partial(_cont_dist_shaper, shaper)


### PR DESCRIPTION
dist_shaper now supports arbitrary lists of bins and labels, a
pbcore.io.dataset.DataSetMembers specific vesion is also available.

Support was expanded to float binwidths and dists with non-identical bins.

Bin widths must still be consistent between distributions and bin locations
must come from the same set of binwidth-multiples.

Backed off the application of dist_shaper to a stats-gathering phase in
filter_stats_xml.

Added tests, better error messages