### PR TITLE
use sampleMean and sampleSize from length distributions instead of inferring from bins

### DIFF
--- a/pbreports/report/filter_stats_xml.py
+++ b/pbreports/report/filter_stats_xml.py
@@ -102,10 +102,8 @@ def _to_read_stats_attributes(readLenDists, readQualDists):
 
     # if a merge failed there may be more than one dist:
     for rlendist in readLenDists:
-        nbases += _total_from_bins(rlendist.bins,
-                                   rlendist.minBinValue,
-                                   rlendist.binWidth)
-        nreads += sum(rlendist.bins)
+        nbases += rlendist.sampleMean * rlendist.sampleSize
+        nreads += rlendist.sampleSize
 
         # N50:
         for i, lbin in enumerate(rlendist.bins):
@@ -132,7 +130,8 @@ def _to_read_stats_attributes(readLenDists, readQualDists):
 
     readlen = 0
     if nreads != 0:
-        readlen = int(np.round(nbases / nreads, decimals=0))
+        readlen = nbases / nreads
+    readlen = int(np.round(readlen, decimals=0))
     readQuality = 0
     if readscorenumber != 0:
         readQuality = np.round(readscoretotal / readscorenumber, decimals=2)

--- a/tests/unit/test_pbreports_report_stats_xml_reports.py
+++ b/tests/unit/test_pbreports_report_stats_xml_reports.py
@@ -282,10 +282,10 @@ class TestXMLstatsRpts(unittest.TestCase):
         self._compare_attribute_values(
             report_d=d,
             expected_d={
-                Constants.A_NBASES:  4464266,
+                Constants.A_NBASES:  4080353,
                 Constants.A_NREADS: 901,
                 Constants.A_READ_N50: 6570,
-                Constants.A_READ_LENGTH: 4955,
+                Constants.A_READ_LENGTH: 4529,
         #        Constants.A_READ_QUALITY: 0.83
             })
 
@@ -314,10 +314,10 @@ class TestXMLstatsRpts(unittest.TestCase):
         self._compare_attribute_values(
             report_d=d,
             expected_d={
-                Constants.A_NBASES:  393167213,
+                Constants.A_NBASES:  342348413,
                 Constants.A_NREADS: 25123,
                 Constants.A_READ_N50: 21884,
-                Constants.A_READ_LENGTH: 15650,
+                Constants.A_READ_LENGTH: 13627,
          #       Constants.A_READ_QUALITY: 0.86
             })
 


### PR DESCRIPTION
(cherry picked from commit d46c95c193fffcf5f66dc59b2ce00f0279a3466f)