### PR TITLE
Fix matplotlib problem

### DIFF
--- a/pbreports/report/coverage.py
+++ b/pbreports/report/coverage.py
@@ -14,6 +14,9 @@ import os.path as op
 import os
 import sys
 
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 import numpy as np
 
 from pbcommand.models.report import Attribute, Report, PlotGroup, Plot, PbReportError


### PR DESCRIPTION
MJ suggested this as a possible fix, and it does work. I'm not sure if it's wise.

Here is the error:
```py
$ python -m pbreports.report.polished_assembly alignment.summary.gff /home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/siv/testkit-jobs/sa3_pipelines/hgap5_fake/synth5k/job_output/tasks/falcon_ns.tasks.task_hgap_run-0/run-gc-gather/gathered.fastq polished_assembly_report.json
Traceback (most recent call last):
  File "/opt/python-2.7.9/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python-2.7.9/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/UNIXHOME/cdunn/repo/pb/pf/smrtanalysis/bioinformatics/ext/pi/pbreports/pbreports/report/polished_assembly.py", line 24, in <module>
    from pbreports.report.coverage import ContigCoverage
  File "/home/UNIXHOME/cdunn/repo/pb/pf/smrtanalysis/bioinformatics/ext/pi/pbreports/pbreports/report/coverage.py", line 17, in <module>
    import matplotlib.pyplot as plt
  File "/lustre/hpcprod/cdunn/pf/lib/python2.7/site-packages/matplotlib/pyplot.py", line 114, in <module>
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
  File "/lustre/hpcprod/cdunn/pf/lib/python2.7/site-packages/matplotlib/backends/__init__.py", line 32, in pylab_setup
    globals(),locals(),[backend_name],0)
  File "/lustre/hpcprod/cdunn/pf/lib/python2.7/site-packages/matplotlib/backends/backend_tkagg.py", line 6, in <module>
    from matplotlib.externals.six.moves import tkinter as Tk
  File "/lustre/hpcprod/cdunn/pf/lib/python2.7/site-packages/matplotlib/externals/six.py", line 199, in load_module
    mod = mod._resolve()
  File "/lustre/hpcprod/cdunn/pf/lib/python2.7/site-packages/matplotlib/externals/six.py", line 113, in _resolve
    return _import_module(self.mod)
  File "/lustre/hpcprod/cdunn/pf/lib/python2.7/site-packages/matplotlib/externals/six.py", line 80, in _import_module
    __import__(name)
  File "/opt/python-2.7.9/lib/python2.7/lib-tk/Tkinter.py", line 39, in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
ImportError: No module named _tkinter
```