### PR TITLE
Fix preassembly report spec

### DIFF
--- a/pbreports/report/specs/preassembly.json
+++ b/pbreports/report/specs/preassembly.json
@@ -146,6 +146,20 @@
             "type": "float",
             "format": "{p:.2f}",
             "description": null
+        },
+        {
+            "id": "preassembled_seed_fragmentation",
+            "name": "Avg number of reads that each seed is broken into.",
+            "type": "float",
+            "format": "{p:.2f}",
+            "description": null
+        },
+        {
+            "id": "preassembled_seed_truncation",
+            "name": "Avg number of bases lost from each seed.",
+            "type": "float",
+            "format": "{p:.2f}",
+            "description": null
         }
     ],
     "id": "preassembly",


### PR DESCRIPTION
This should have been based on the code which actually produces the report:
* https://github.com/PacificBiosciences/FALCON-pbsmrtpipe/blob/master/pbfalcon/report_preassembly.py#L77

I would have been happy to review #191 for you. Just a bit of communication can avoid a lot of problems.

re: SL-246