### PR TITLE
Fixes occasional 'TclError: no display name and no DISPLAY environment variable'

### DIFF
--- a/pbreports/__init__.py
+++ b/pbreports/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (3, 2, 2)
+VERSION = (3, 2, 3)
 
 
 def get_version():

--- a/pbreports/report/mapping_stats.py
+++ b/pbreports/report/mapping_stats.py
@@ -3,6 +3,9 @@
 Generates a report of statistics for subreads mapped to a reference genome with
 Blasr/pbalign.
 """
+# a wart, but enforces matplotlib headless compat. fixes "TclError: no display name and no $DISPLAY environment variable" errors that sometimes mysteriously appear.
+import matplotlib
+matplotlib.use("Agg")
 
 from collections import OrderedDict
 import multiprocessing


### PR DESCRIPTION
CC @natechols @evolvedmicrobe @mpkocher 

This is a wart, but it fixes an error that was really annoying. After install of all dependencies, the code would run but fail at matplotlib use with errors such as the below. I could also reproduce it with any custom matplot lib use that didn't set `agg`.

Frustratingly, I couldn't figure out how to set an ENV variable that'd omit the need for this. I even tried altering `/usr/bin/python` to be a script that set the ENV and they invoked python. I wish I knew the root cause here, but it seems to be an import order issue of matplotlib and ensuring `Agg` is set.

```bash
no display name and no $DISPLAY environment variable
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/pbcommand/cli/core.py", line 136, in _pacbio_main_runner
    return_code = exe_main_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pbreports/report/mapping_stats.py", line 1022, in _resolved_tool_contract_runner
    json_report=resolved_contract.task.output_files[0])
  File "/usr/local/lib/python2.7/dist-packages/pbreports/report/mapping_stats.py", line 1002, in run_and_write_report
    report = report_func(alignment_file, output_dir)
  File "/usr/local/lib/python2.7/dist-packages/pbreports/report/mapping_stats.py", line 980, in to_report
    return spec.apply_view(MappingStatsCollector(alignment_file).to_report(output_dir))
  File "/usr/local/lib/python2.7/dist-packages/pbreports/report/mapping_stats.py", line 954, in to_report
    id_to_aggregators)
  File "/usr/local/lib/python2.7/dist-packages/pbreports/report/streaming_utils.py", line 325, in to_plot_groups
    fig, ax = plot_view.plot_func(aggregator, plot_view, output_dir)
  File "/usr/local/lib/python2.7/dist-packages/pbreports/report/streaming_utils.py", line 212, in _generate_plot
    fig, ax = f(aggregator, plot_view, output_dir)
  File "/usr/local/lib/python2.7/dist-packages/pbreports/report/streaming_utils.py", line 134, in plot_aggregator_histogram
    fig, ax = get_fig_axes_lpr()
  File "/usr/local/lib/python2.7/dist-packages/pbreports/plot/helper.py", line 15, in get_fig_axes_lpr
    fig, ax = get_fig_axes(dims, facecolor, gridcolor)
  File "/usr/local/lib/python2.7/dist-packages/pbreports/plot/helper.py", line 27, in get_fig_axes
    fig = plt.figure(figsize=dims)
  File "/usr/lib/pymodules/python2.7/matplotlib/pyplot.py", line 423, in figure
    **kwargs)
  File "/usr/lib/pymodules/python2.7/matplotlib/backends/backend_tkagg.py", line 79, in new_figure_manager
    return new_figure_manager_given_figure(num, figure)
  File "/usr/lib/pymodules/python2.7/matplotlib/backends/backend_tkagg.py", line 87, in new_figure_manager_given_figure
    window = Tk.Tk()
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1767, in __init__
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
TclError: no display name and no $DISPLAY environment variable
```

Any ideas for a better fix? If this wart merits propagating everywhere then maybe `pbreports/__init__.py` is where it should live.

I was seeing this on Ubuntu 14.04 setups of smrtflow. I'm curious if CentOS7 has the same. In any case, a frustrating one where this seems to be the fix.