### PR TITLE
force matplotlib to always use Agg backend

### DIFF
--- a/pbreports/__init__.py
+++ b/pbreports/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (3, 2, 2)
+VERSION = (3, 2, 3)
 
 
 def get_version():

--- a/pbreports/plot/helper.py
+++ b/pbreports/plot/helper.py
@@ -3,6 +3,10 @@ import os
 import logging
 
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +27,6 @@ def get_fig_axes(dims=(8, 6), facecolor='#e0e0e0', gridcolor='#ffffff'):
     Get a matplotlib figure object.
     This theme is background (default=gray) and grid lines (default=white).
     """
-    import matplotlib.pyplot as plt
     fig = plt.figure(figsize=dims)
     fig.patch.set_alpha(0.5)
     ax = fig.add_subplot(111)
@@ -141,7 +144,6 @@ def apply_line_data(ax, line_models,
 
 
 def apply_bar_data(ax, bars, labels, axis_labels=('', ''), data_file=None):
-    import matplotlib.ticker as ticker
 
     def y_height_sort(i, j):
         """Basically a sorting comparator for rectangles"""
@@ -304,7 +306,6 @@ def save_figure_with_thumbnail(figure, filename, dpi=60):
 
     returns a tuple of (basename of image, basename of thumbnail)
     """
-    import matplotlib.pyplot as plt
     parts = os.path.splitext(filename)
     thumb = '{b}_thumb{e}'.format(b=parts[0], e=parts[1])
     _save_figures(figure, [(filename, dpi), (thumb, 20)])

--- a/pbreports/plot/rainbow.py
+++ b/pbreports/plot/rainbow.py
@@ -13,6 +13,9 @@ import os
 import sys
 
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from pbcore.io import openDataFile, DataSet, CmpH5Reader
 from pbcommand.models.report import Report, PlotGroup, Plot
@@ -110,7 +113,6 @@ def _read_in_indexed_alignmentset(in_fn, reference=None):
 
 def _make_plot(data, png_fn, bounds=None, dpi=60, nolegend=False):
     """Make a scatterplot of read length and concordance"""
-    import matplotlib.pyplot as plt
     fig = plt.figure()
     axes = fig.add_subplot(111)
     axes.axesPatch.set_facecolor('#ffffff')

--- a/pbreports/report/ccs.py
+++ b/pbreports/report/ccs.py
@@ -18,6 +18,9 @@ import time
 from pprint import pformat
 
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from pbcommand.models.report import (Report, Table, Column, Attribute, Plot,
                                      PlotGroup)
@@ -393,7 +396,6 @@ def create_plot(_make_plot_func, plot_id, axis_labels, nbins, plot_name, barcolo
     plot config options.
     """
 
-    import matplotlib.pyplot as plt
     fig, ax = _make_plot_func(data, axis_labels, nbins, barcolor)
     path = os.path.join(output_dir, plot_name)
     try:

--- a/pbreports/report/ccs_validator_report.py
+++ b/pbreports/report/ccs_validator_report.py
@@ -10,6 +10,9 @@ import os.path as op
 import sys
 
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from pbcommand.models.report import Table, Column, Report, Plot, PlotGroup
 from pbcommand.validators import validate_dir, validate_file
@@ -134,7 +137,6 @@ def fastq_files_to_stats(fastq_files):
 
 def to_report(fastq_files, qv_hist=None, readlength_hist=None):
     """Generate a histogram of read lengths and quality values"""
-    import matplotlib.pyplot as plt
     fastq_stats = fastq_files_to_stats(fastq_files)
 
     table = _generate_table(fastq_stats.values())

--- a/pbreports/report/control.py
+++ b/pbreports/report/control.py
@@ -10,6 +10,9 @@ import array
 import sys
 
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.patches as mp
 
 from pbcommand.models.report import (Attribute, Report, PlotGroup, Plot,
                                      PbReportError)
@@ -273,7 +276,6 @@ def _create_length_figure(control_data, sample_data):
 def _apply_plot_data(x_data, y1_data, y2_data, labels, legend_loc=None):
     """Default labels assume y1_data==control, y2_data==sample"""
 
-    import matplotlib.patches as mp
     h1_color = '#5050f0'
     h2_color = '#f05050'
 

--- a/pbreports/report/coverage.py
+++ b/pbreports/report/coverage.py
@@ -15,6 +15,9 @@ import os
 import sys
 
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from pbcommand.models.report import Attribute, Report, PlotGroup, Plot, PbReportError
 from pbcommand.models import FileTypes, get_pbparser
@@ -62,7 +65,6 @@ def _create_coverage_plot_grp(top_contigs, cov_map, output_dir):
     :param cov_map: (dict string:ContigCoverage) mapping of contig.id to ContigCoverage object
     :param output_dir: (string) where to write images
     """
-    import matplotlib.pyplot as plt
     plots = []
     thumbnail = None
     idx = 0

--- a/pbreports/report/isoseq_classify.py
+++ b/pbreports/report/isoseq_classify.py
@@ -12,6 +12,9 @@ import argparse
 from pprint import pformat
 
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from pbcommand.models.report import (Report, Table, Column, Attribute, Plot,
                                      PlotGroup)
@@ -129,7 +132,6 @@ def __create_plot(_make_plot_func, plot_id, axis_labels, nbins,
     plot config options.
     """
 
-    import matplotlib.pyplot as plt
     fig, _ax = _make_plot_func(datum, axis_labels, nbins, barcolor)
     path = os.path.join(output_dir, plot_name)
     try:

--- a/pbreports/report/isoseq_cluster.py
+++ b/pbreports/report/isoseq_cluster.py
@@ -14,6 +14,9 @@ import logging
 import argparse
 
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from pbcommand.models.report import (Report, Table, Column, Attribute, Plot,
                                      PlotGroup)
@@ -132,7 +135,6 @@ def __create_plot(_make_plot_func, plot_id, axis_labels, nbins,
     plot config options.
     """
 
-    import matplotlib.pyplot as plt
     fig, _ax = _make_plot_func(datum, axis_labels, nbins, barcolor)
     path = os.path.join(output_dir, plot_name)
     try:

--- a/pbreports/report/motifs.py
+++ b/pbreports/report/motifs.py
@@ -16,6 +16,9 @@ import argparse
 import operator
 
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from pbcommand.models.report import Report, PlotGroup, Plot, Table, Column
 from pbcommand.models import TaskTypes, FileTypes, get_pbparser
@@ -187,7 +190,6 @@ def setAxisLabelFontSize(ax, labelSize):
 
 
 def _createFigTemplate(dims=(8, 6), facecolor='#ffffff', gridcolor='#e0e0e0'):
-    import matplotlib.pyplot as plt
     fig = plt.figure(figsize=dims)
     ax = fig.add_subplot(111)
     ax.axesPatch.set_facecolor(facecolor)
@@ -243,7 +245,6 @@ def readModificationCsvGz(fn):
 
 def plotKineticsScatter(kinArr, outputFileName):
 
-    import matplotlib.pyplot as plt
     handles = []
     colors = ['red', 'green', 'blue', 'magenta']
     bases = ['A', 'C', 'G', 'T']
@@ -279,7 +280,6 @@ def plotKineticsScatter(kinArr, outputFileName):
 
 def plotKineticsHist(kinArr, outputFileName):
 
-    import matplotlib.pyplot as plt
     colors = ['red', 'green', 'blue', 'magenta']
     bases = ['A', 'C', 'G', 'T']
 
@@ -437,7 +437,6 @@ def excludeSparseRegions(data):
 
 
 def plotMotifHist(csvFile, kinArr, max_motifs=10):
-    import matplotlib.pyplot as plt
     # Use kinArr to determine number of motifs:
     # motifs = np.unique( kinArr['motif'] )
 

--- a/pbreports/report/streaming_utils.py
+++ b/pbreports/report/streaming_utils.py
@@ -8,6 +8,9 @@ import logging
 import functools
 import types
 
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from pbcommand.models.report import Plot, PlotGroup
 
@@ -308,7 +311,6 @@ def to_plot_groups(view_config_d, output_dir, id_to_aggregators):
     Make custom func on plot view?
     """
 
-    import matplotlib.pyplot as plt
     plots_by_group_id = {}
 
     # Messy way to set the PlotGroup

--- a/pbreports/report/variants.py
+++ b/pbreports/report/variants.py
@@ -14,6 +14,9 @@ import sys
 import hashlib
 
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from pbcommand.models.report import (Table, Column, Attribute, Report,
                                      PlotGroup, Plot, PbReportError)
@@ -163,7 +166,6 @@ def _create_variants_plot_grp(top_contigs, var_map, output_dir):
     :param var_map: (dict string:ContigVariants) mapping of contig.header to ContigVariants object
     :param output_dir: (string) where to write images
     """
-    import matplotlib.pyplot as plt
     plots = []
     thumbnail = None
     legend = None
@@ -212,7 +214,6 @@ def _get_legend_file(bars, output_dir):
     :param output_dir: Where to write file
     :return (string) filename
     """
-    import matplotlib.pyplot as plt
     fig = PH.get_bar_plot_legend_fig(bars)
     fname = 'variants_plot_legend.png'
     fig.savefig(os.path.join(output_dir, fname), dpi=60)


### PR DESCRIPTION
Supersedes #213.  This reverts my earlier change to inline all matplotlib imports, because the backend issues are way more broken.